### PR TITLE
Setup clean virtual python environment using "actions/python"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '>=3.6'
     - run: pip install -r ${{ github.action_path }}/requirements.txt
       shell: bash
     - run: python ${{ github.action_path }}/src/ollama_review.py


### PR DESCRIPTION
Hi, I'm having some issues running this action on a custom runner image (e.g. `catthehacker/ubuntu` [1]), so I'll figure I'll upstream this fix.

Avoid the `error: externally-managed-environment` [2] issue that arises when installing pip dependencies directly in the global python environment.
By using `actions/setup-python`, a clean, isolated python environment is configured to run the python script with the required pip dependencies, avoiding breaking the global python environment.
The `python-version: '>=3.6'` was added since the python code depends on the `f-strings` feature.

The change makes this action depend on node24 (released in 2025-04-22 and current LTS release). If used with `actions/setup-python@v5`, it lowers the dependency to node20 (released in 2023-04-18 and EOL release).

[1] https://github.com/catthehacker/docker_images
[2] https://packaging.python.org/en/latest/specifications/externally-managed-environments/